### PR TITLE
Fixes #6

### DIFF
--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -668,6 +668,19 @@ def run():
                 logger.error('ffmpeg exited with the code: {0!s}'.format(exit_code))
                 logger.error('Command: {0!s}'.format(' '.join(cmd)))
                 exit(exit_code)
+            
+            if os.path.isfile(cover_filename):  # embed cover art using mp4art
+                cmd = [
+                    'mp4art',
+                    '--verbose', '3' if logger.level == logging.DEBUG else '1',
+                    '--add', cover_filename,
+                    temp_book_m4b_filename]
+                exit_code = subprocess.call(cmd)
+
+                if exit_code:
+                    logger.error('mp4art exited with the code: {0!s}'.format(exit_code))
+                    logger.error('Command: {0!s}'.format(' '.join(cmd)))
+                    exit(exit_code)
 
             os.rename(temp_book_m4b_filename, book_m4b_filename)
             logger.info('Merged files into "{}"'.format(colored.magenta(book_m4b_filename)))
@@ -675,19 +688,6 @@ def run():
                 os.remove(book_filename)
             except Exception as e:
                 logger.warning('Error deleting "{}": {}'.format(book_filename, str(e)))
-
-        if args.merge_format == 'm4b':  # embed cover art using mp4art
-            cmd = [
-                'mp4art',
-                '--verbose', '3' if logger.level == logging.DEBUG else '1',
-                '--add', cover_filename,
-                book_m4b_filename]
-            exit_code = subprocess.call(cmd)
-
-            if exit_code:
-                logger.error('mp4art exited with the code: {0!s}'.format(exit_code))
-                logger.error('Command: {0!s}'.format(' '.join(cmd)))
-                exit(exit_code)
 
         if not args.keep_mp3:
             for f in file_tracks:

--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -650,7 +650,7 @@ def run():
             logger.info('Merged files into "{}"'.format(
                 colored.magenta(book_filename if args.merge_format == 'mp3' else book_m4b_filename)))
 
-        if args.merge_format == 'm4b':
+        if args.merge_format == 'm4b':  # encode merged mp3 into mp4/m4b
             temp_book_m4b_filename = '{}.part'.format(book_filename)
             cmd = [
                 'ffmpeg', '-y',
@@ -675,6 +675,19 @@ def run():
                 os.remove(book_filename)
             except Exception as e:
                 logger.warning('Error deleting "{}": {}'.format(book_filename, str(e)))
+
+        if args.merge_format == 'm4b':  # embed cover art using mp4art
+            cmd = [
+                'mp4art',
+                '--verbose', '3' if logger.level == logging.DEBUG else '1',
+                '--add', cover_filename,
+                book_m4b_filename]
+            exit_code = subprocess.call(cmd)
+
+            if exit_code:
+                logger.error('mp4art exited with the code: {0!s}'.format(exit_code))
+                logger.error('Command: {0!s}'.format(' '.join(cmd)))
+                exit(exit_code)
 
         if not args.keep_mp3:
             for f in file_tracks:

--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -657,6 +657,7 @@ def run():
                 '-hide_banner',
                 '-loglevel', 'info' if logger.level == logging.DEBUG else 'error', '-stats',
                 '-i', book_filename,
+                '-map', '0:a',          # ignore the video track (embedded artwork so ffmpeg command will not fail)
                 '-c:a', 'aac',
                 '-b:a', '64k',          # explicitly set audio bitrate
                 '-f', 'mp4',


### PR DESCRIPTION
I modified the script to ignore the embedded cover art in the merged mp3 because that was causing an ffmpeg error (ffmpeg version 4.3.1)

After the conversion to mp4/m4b is complete we use mp4art to embed the covert art. This creates a new dependency. mp4art is part of mp4v2 tools (brew install mp4v2)