### PR TITLE
Fixes #8

### DIFF
--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -471,9 +471,8 @@ def run():
                         tree = xml.etree.ElementTree.fromstring(frame.text.encode('ascii', 'ignore').decode('ascii'))
 
                     for m in tree.iter('Marker'):
-                        marker_name = m.find('Name').text
+                        marker_name = m.find('Name').text.strip()
                         marker_timestamp = m.find('Time').text
-
                         timestamp = None
                         ts_mark = 0
                         for r in ('%M:%S.%f', '%H:%M:%S.%f'):


### PR DESCRIPTION
Added strip() when reading chapter names to remove extra white spaces.

` odmpy -v dl -c -k -f -j  multipart.odm `

Output before:
```
Added chap tag => ch02: 0:00:00-0:18:54 "      Black Rain (00:00)" to "./The Invincible - Stanislaw Lem/the-invincible-part-02.mp3"
Added chap tag => ch13: 0:38:33-1:07:39.361000 "      Invincible (38:33)" to "./The Invincible - Stanislaw Lem/the-invincible-part-07.mp3"
```

Output after
```
Added chap tag => ch02: 0:00:00-0:18:54 "Black Rain (00:00)" to "./The Invincible - Stanislaw Lem/the-invincible-part-02.mp3"
Added chap tag => ch13: 0:38:33-1:07:39.361000 "Invincible (38:33)" to "./The Invincible - Stanislaw Lem/the-invincible-part-07.mp3"

```