### PR TITLE
Fixes #10

### DIFF
--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -678,7 +678,7 @@ def run():
 
             if os.path.isfile(cover_filename):
                 cmd.extend([
-                    '-c', 'copy',
+                    '-c:v', 'copy',
                     '-disposition:v:0', 'attached_pic',
                 ])
             cmd.extend([


### PR DESCRIPTION
When encoding the m4b, the codec for the image can be specified as `-c:v copy -disposition:v:0 attached_pic` to avoid the warning message about multiple -c options.

`-i file.mp3 -i cover.jpg -map 0:a -map 1 -c:v copy -disposition:v:0 attached_pic -c:a aac -b:a 64k -f mp4 test.m4b`
