### PR TITLE
Use the Editor name when the author tag is missing

### DIFF
--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -218,6 +218,10 @@ def run():
         unescape_html(c.text) for c in metadata.find('Creators')
         if 'Author' in c.attrib.get('role', '')]
     if not authors:
+        authors = [
+            unescape_html(c.text) for c in metadata.find('Creators')
+            if 'Editor' in c.attrib.get('role', '')]
+    if not authors:
         authors = [unescape_html(c.text) for c in metadata.find('Creators')]
     publisher = metadata.find('Publisher').text
     description = metadata.find('Description').text if metadata.find('Description') is not None else ''


### PR DESCRIPTION
This could help with #5 in the case of compilations, when the odm has no Author credit it will search for an Editor, if that is missing too it will continue to use all the Creaters names.