### PR TITLE
Changes for #14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 clint
 mutagen
+pillow

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             'odmpy = odmpy.__main__:main',
         ]
     },
-    install_requires=['requests', 'clint', 'mutagen'],
+    install_requires=['requests', 'clint', 'mutagen','pillow'],
     include_package_data=True,
     platforms='any',
     long_description=__long_description__,


### PR DESCRIPTION
 Change the cover aspect ratio to 1:1 before writing to disk, so all files (individual mp3s and merged files) get the corrected cover embedded.
Creates a new dependency for PIL (Python Image Libray) so we can manipulate the image in memory and write to disk only once.