### PR TITLE
add json mode for info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,17 @@ optional arguments:
 ```
 
 ```
-usage: odmpy info [-h] odm_file
+usage: odmpy info [-h] [-f {text,json}] odm_file
 
 Get information about a loan file.
 
 positional arguments:
-  odm_file    ODM file path
+  odm_file              ODM file path
 
 optional arguments:
-  -h, --help  show this help message and exit
+  -h, --help            show this help message and exit
+  -f {text,json}, --format {text,json}
+                        Format for output
 ```
 
 ### Examples


### PR DESCRIPTION
Duplicate of #20, but without source formatting changes.

I was also thinking about a patch that allowed a single output file to a destination. The workflow I ultimately want to support is turning a single `odm` file into a single `m4b` file, like: `odmpy some/path.odm -cm --mergeformat m4b -o path/to/audiobooks`. I think that's fairly straightforward. 

It would also be cool to be able to clean up files during a return- delete the `odm` and `license`, but that could be a separate patch.