### PR TITLE
Add encoding on open statements and sysout reconfigure for windows

### DIFF
--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -24,7 +24,8 @@ import json
 import logging
 import os
 import sys
-sys.stdout.reconfigure(encoding='utf-8')
+
+sys.stdout.reconfigure(encoding="utf-8")
 import time
 import xml.etree.ElementTree
 from enum import Enum

--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -25,7 +25,6 @@ import json
 import logging
 import os
 import sys
-
 import time
 import xml.etree.ElementTree
 from enum import Enum

--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -20,12 +20,12 @@
 
 import argparse
 import datetime
+import io
 import json
 import logging
 import os
 import sys
 
-sys.stdout.reconfigure(encoding="utf-8")
 import time
 import xml.etree.ElementTree
 from enum import Enum
@@ -44,7 +44,7 @@ from .utils import slugify, get_element_text
 
 logger = logging.getLogger(__file__)
 requests_logger = logging.getLogger("urllib3")
-ch = logging.StreamHandler(sys.stdout)
+ch = logging.StreamHandler(io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
 ch.setLevel(logging.DEBUG)
 logger.addHandler(ch)
 logger.setLevel(logging.INFO)

--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import sys
+sys.stdout.reconfigure(encoding='utf-8')
 import time
 import xml.etree.ElementTree
 from enum import Enum

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -374,7 +374,7 @@ class OdmpyTests(unittest.TestCase):
         test_file = os.path.join(self.book_folder, "ceremonies-for-christmas.opf")
         self.assertTrue(os.path.isfile(test_file))
 
-        with open(test_file) as actual, open(
+        with open(test_file, encoding="utf-8") as actual, open(
             schema_file, "r", encoding="utf-8"
         ) as schema:
             actual_opf = etree.parse(actual)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -167,7 +167,7 @@ class OdmpyTests(unittest.TestCase):
             self.test_data_dir, "{}.info.expected.txt".format(self.test_file)
         )
         test_file = os.path.join(self.test_data_dir, "test.odm.info.txt")
-        with open(expected_file) as expected, open(test_file) as actual:
+        with open(expected_file, encoding="utf-8") as expected, open(test_file, encoding="utf-8") as actual:
             expected_text = expected.read()
             actual_text = actual.read()
             self.assertEqual(expected_text, actual_text)
@@ -278,7 +278,7 @@ class OdmpyTests(unittest.TestCase):
         """
         json_file = os.path.join(self.test_data_dir, "output.mp3.json")
         last_end = 0
-        with open(json_file) as f:
+        with open(json_file, encoding="utf-8") as f:
             meta = json.load(f)
             self.assertEqual(len(meta.get("chapters", [])), self.total_chapters)
             for ch in meta["chapters"]:
@@ -317,7 +317,7 @@ class OdmpyTests(unittest.TestCase):
         """
         json_file = os.path.join(self.test_data_dir, "output.m4b.json")
         last_end = 0
-        with open(json_file) as f:
+        with open(json_file, encoding="utf-8") as f:
             meta = json.load(f)
             self.assertEqual(len(meta.get("chapters", [])), self.total_chapters)
             for ch in meta["chapters"]:


### PR DESCRIPTION
Got most of the tests to pass for windows with this. Should work for unix as well.

NOTE: sys.stdout.reconfigure(encoding='utf-8') is python 3.7+

The encoding problem on windows was created by using 
run_tests.sh
```
python -m odmpy info -f json "$TEST_DATA_DIR/$TEST_ODM" > "$TEST_DATA_DIR/test.odm.info.json"
```
to write files from std out using the console causing the tests to crash.

The added "open encodings" fixed other tests which failed.