### PR TITLE
add --mergecodec option, add support for using libfdk_aac

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ You will be prompted for a Libby setup code the first time you run the `libby` c
 ```
 usage: odmpy libby [-h] [--settings SETTINGS_FOLDER] [--ebooks] [--magazines]
                    [--noaudiobooks] [-d DOWNLOAD_DIR] [-c] [-m]
-                   [--mergeformat {mp3,m4b}] [-k] [-f] [--nobookfolder]
+                   [--mergeformat {mp3,m4b}] [--mergecodec {aac,libfdk_aac}]
+                   [-k] [-f] [--nobookfolder]
                    [--bookfolderformat BOOK_FOLDER_FORMAT]
                    [--bookfileformat BOOK_FILE_FORMAT] [--overwritetags]
                    [--tagsdelimiter DELIMITER] [--id3v2version {3,4}] [--opf]
@@ -122,6 +123,8 @@ options:
   -m, --merge           Merge into 1 file (experimental, requires ffmpeg). For audiobooks.
   --mergeformat {mp3,m4b}
                         Merged file format (m4b is slow, experimental, requires ffmpeg). For audiobooks.
+  --mergecodec {aac,libfdk_aac}
+                        Audio codec of merged m4b file. (requires ffmpeg, using libfdk_aac requires ffmpeg compiled with libfdk_aac support). For audiobooks. Has no effect if mergeformat is mp3.
   -k, --keepcover       Always generate the cover image file (cover.jpg).
   -f, --keepmp3         Keep downloaded mp3 files (after merging). For audiobooks.
   --nobookfolder        Don't create a book subfolder.

--- a/example.dl.conf
+++ b/example.dl.conf
@@ -3,3 +3,4 @@
 --chapters
 --merge
 --mergeformat=m4b
+--mergecodec=aac

--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -169,6 +169,13 @@ def add_common_download_arguments(parser_dl: argparse.ArgumentParser) -> None:
         help="Merged file format (m4b is slow, experimental, requires ffmpeg). For audiobooks.",
     )
     parser_dl.add_argument(
+        "--mergecodec",
+        dest="merge_codec",
+        choices=["aac", "libfdk_aac"],
+        default="aac",
+        help="Audio codec of merged m4b file. (requires ffmpeg; using libfdk_aac requires ffmpeg compiled with libfdk_aac support). For audiobooks. Has no effect if mergeformat is not set to m4b.",
+    )
+    parser_dl.add_argument(
         "-k",
         "--keepcover",
         dest="always_keep_cover",

--- a/odmpy/processing/audiobook.py
+++ b/odmpy/processing/audiobook.py
@@ -442,6 +442,7 @@ def process_audiobook_loan(
                 book_filename=book_filename,
                 book_m4b_filename=book_m4b_filename,
                 cover_filename=cover_filename,
+                merge_codec=args.merge_codec,
                 audio_bitrate=audio_bitrate,
                 ffmpeg_loglevel=ffmpeg_loglevel,
                 hide_progress=args.hide_progress,

--- a/odmpy/processing/odm.py
+++ b/odmpy/processing/odm.py
@@ -738,6 +738,7 @@ def process_odm(
                 book_filename=book_filename,
                 book_m4b_filename=book_m4b_filename,
                 cover_filename=cover_filename,
+                merge_codec=args.merge_codec,
                 audio_bitrate=audio_bitrate,
                 ffmpeg_loglevel=ffmpeg_loglevel,
                 hide_progress=args.hide_progress,

--- a/odmpy/processing/shared.py
+++ b/odmpy/processing/shared.py
@@ -408,6 +408,7 @@ def convert_to_m4b(
     book_filename: Path,
     book_m4b_filename: Path,
     cover_filename: Path,
+    merge_codec: str,
     audio_bitrate: int,
     ffmpeg_loglevel: str,
     hide_progress: str,
@@ -419,6 +420,7 @@ def convert_to_m4b(
     :param book_filename: mp3 file name
     :param book_m4b_filename:
     :param cover_filename:
+    :param merge_codec:
     :param audio_bitrate:
     :param ffmpeg_loglevel:
     :param hide_progress:
@@ -450,7 +452,7 @@ def convert_to_m4b(
             "-map",
             "0:a",
             "-c:a",
-            "aac",
+            merge_codec,
             "-b:a",
             f"{audio_bitrate}k"
             if audio_bitrate


### PR DESCRIPTION
If merged, users who have compiled ffmpeg with libfdk_aac support will be able to specify ```--mergecodec="libfdk_aac"``` to use the Fraunhofer FDK AAC audio codec instead of the default AAC when ```--mergeformat``` is set to ```m4b```, which results in significantly faster encoding.

```mergecodec``` defaults to aac if not specified. In the event of setting ```mergecodec``` to a value without setting ```--mergeformat=m4b```, this option is ignored.

### Example of speed difference:
With the default aac encoder, the ffmpeg output on my machine indicates a speed of ~47x during the m4b creation. With ```--mergecodec="libfdk_aac"```, the speed for creation of the same audiobook m4b file is ~129x.