### PR TITLE
Fix published_date parsing

### DIFF
--- a/odmpy/libby_errors.py
+++ b/odmpy/libby_errors.py
@@ -77,8 +77,8 @@ class ErrorHandler(object):
         :return:
         """
         # json response
-        if http_err.response is not None :
-            if hasattr(http_err.response, 'json') and callable(http_err.response.json):
+        if http_err.response is not None:
+            if hasattr(http_err.response, "json") and callable(http_err.response.json):
                 if (
                     http_err.response.status_code == HTTPStatus.BAD_REQUEST
                     and http_err.response.headers.get("content-type", "").startswith(
@@ -100,7 +100,7 @@ class ErrorHandler(object):
                             http_status=http_err.response.status_code,
                             error_response=http_err.response.text,
                         ) from http_err
-                    
+
                 # final fallback
                 raise ClientError(
                     msg=str(http_err),

--- a/odmpy/libby_errors.py
+++ b/odmpy/libby_errors.py
@@ -77,31 +77,33 @@ class ErrorHandler(object):
         :return:
         """
         # json response
-        if (
-            http_err.response.status_code == HTTPStatus.BAD_REQUEST
-            and http_err.response.headers.get("content-type", "").startswith(
-                "application/json"
-            )
-        ):
-            error = http_err.response.json()
-            if error.get("result", "") == "upstream_failure":
-                upstream = error.get("upstream", {})
-                if upstream:
-                    raise ClientBadRequestError(
-                        msg=f'{upstream.get("userExplanation", "")} [errorcode: {upstream.get("errorCode", "")}]',
-                        http_status=http_err.response.status_code,
-                        error_response=http_err.response.text,
-                    ) from http_err
+        if http_err.response is not None :
+            if hasattr(http_err.response, 'json') and callable(http_err.response.json):
+                if (
+                    http_err.response.status_code == HTTPStatus.BAD_REQUEST
+                    and http_err.response.headers.get("content-type", "").startswith(
+                        "application/json"
+                    )
+                ):
+                    error = http_err.response.json()
+                    if error.get("result", "") == "upstream_failure":
+                        upstream = error.get("upstream", {})
+                        if upstream:
+                            raise ClientBadRequestError(
+                                msg=f'{upstream.get("userExplanation", "")} [errorcode: {upstream.get("errorCode", "")}]',
+                                http_status=http_err.response.status_code,
+                                error_response=http_err.response.text,
+                            ) from http_err
 
-                raise ClientBadRequestError(
-                    msg=str(error),
+                        raise ClientBadRequestError(
+                            msg=str(error),
+                            http_status=http_err.response.status_code,
+                            error_response=http_err.response.text,
+                        ) from http_err
+                    
+                # final fallback
+                raise ClientError(
+                    msg=str(http_err),
                     http_status=http_err.response.status_code,
                     error_response=http_err.response.text,
                 ) from http_err
-
-        # final fallback
-        raise ClientError(
-            msg=str(http_err),
-            http_status=http_err.response.status_code,
-            error_response=http_err.response.text,
-        ) from http_err

--- a/odmpy/processing/audiobook.py
+++ b/odmpy/processing/audiobook.py
@@ -245,8 +245,9 @@ def process_audiobook_loan(
                 )
 
             except HTTPError as he:
-                logger.error(f"HTTPError: {str(he)}")
-                logger.debug(he.response.content)
+                if he.response is not None :
+                    logger.error(f"HTTPError: {str(he)}")
+                    logger.debug(he.response.content)
                 raise OdmpyRuntimeError("HTTP Error while downloading part file.")
 
             except ConnectionError as ce:

--- a/odmpy/processing/audiobook.py
+++ b/odmpy/processing/audiobook.py
@@ -245,7 +245,7 @@ def process_audiobook_loan(
                 )
 
             except HTTPError as he:
-                if he.response is not None :
+                if he.response is not None:
                     logger.error(f"HTTPError: {str(he)}")
                     logger.debug(he.response.content)
                 raise OdmpyRuntimeError("HTTP Error while downloading part file.")

--- a/odmpy/processing/ebook.py
+++ b/odmpy/processing/ebook.py
@@ -861,7 +861,7 @@ def process_ebook_loan(
 
     # Ignoring mypy error below because of https://github.com/python/mypy/issues/9372
     spine_entries = sorted(
-        spine_entries, key=cmp_to_key(lambda a, b: _sort_spine_entries(a, b, toc_pages))  # type: ignore[misc]
+        spine_entries, key=cmp_to_key(lambda a, b: _sort_spine_entries(a, b, toc_pages))  # type: ignore[misc,arg-type]
     )
     for spine_idx, entry in enumerate(spine_entries):
         if (

--- a/odmpy/processing/odm.py
+++ b/odmpy/processing/odm.py
@@ -372,14 +372,15 @@ def process_odm(
             logger.debug(f"Saved license file {license_file}")
 
         except HTTPError as he:
-            if he.response.status_code == 404:
-                # odm file has expired
-                logger.error(
-                    f'The loan file "{args.odm_file}" has expired. Please download again.'
-                )
-            else:
-                logger.error(he.response.content)
-            raise OdmpyRuntimeError("HTTP Error while downloading license.")
+            if he.response is not None :
+                if he.response.status_code == 404:
+                    # odm file has expired
+                    logger.error(
+                        f'The loan file "{args.odm_file}" has expired. Please download again.'
+                    )
+                else:
+                    logger.error(he.response.content)
+                raise OdmpyRuntimeError("HTTP Error while downloading license.")
         except ConnectionError as ce:
             logger.error(f"ConnectionError: {str(ce)}")
             raise OdmpyRuntimeError("Connection Error while downloading license.")
@@ -461,8 +462,9 @@ def process_odm(
                 )
 
             except HTTPError as he:
-                logger.error(f"HTTPError: {str(he)}")
-                logger.debug(he.response.content)
+                if he.response is not None :
+                    logger.error(f"HTTPError: {str(he)}")
+                    logger.debug(he.response.content)
                 raise OdmpyRuntimeError("HTTP Error while downloading part file.")
 
             except ConnectionError as ce:
@@ -832,11 +834,12 @@ def process_odm_return(args: argparse.Namespace, logger: logging.Logger) -> None
         early_return_res.raise_for_status()
         logger.info(f"Loan returned successfully: {args.odm_file}")
     except HTTPError as he:
-        if he.response.status_code == 403:
-            logger.warning("Loan is probably already returned.")
-            return
-        logger.error(f"HTTPError: {str(he)}")
-        logger.debug(he.response.content)
+        if he.response is not None :
+            if he.response.status_code == 403:
+                logger.warning("Loan is probably already returned.")
+                return
+            logger.error(f"HTTPError: {str(he)}")
+            logger.debug(he.response.content)
         raise OdmpyRuntimeError(f"HTTP error returning odm {args.odm_file, }")
     except ConnectionError as ce:
         logger.error(f"ConnectionError: {str(ce)}")

--- a/odmpy/processing/odm.py
+++ b/odmpy/processing/odm.py
@@ -372,7 +372,7 @@ def process_odm(
             logger.debug(f"Saved license file {license_file}")
 
         except HTTPError as he:
-            if he.response is not None :
+            if he.response is not None:
                 if he.response.status_code == 404:
                     # odm file has expired
                     logger.error(
@@ -462,7 +462,7 @@ def process_odm(
                 )
 
             except HTTPError as he:
-                if he.response is not None :
+                if he.response is not None:
                     logger.error(f"HTTPError: {str(he)}")
                     logger.debug(he.response.content)
                 raise OdmpyRuntimeError("HTTP Error while downloading part file.")
@@ -834,7 +834,7 @@ def process_odm_return(args: argparse.Namespace, logger: logging.Logger) -> None
         early_return_res.raise_for_status()
         logger.info(f"Loan returned successfully: {args.odm_file}")
     except HTTPError as he:
-        if he.response is not None :
+        if he.response is not None:
             if he.response.status_code == 403:
                 logger.warning("Loan is probably already returned.")
                 return

--- a/odmpy/processing/shared.py
+++ b/odmpy/processing/shared.py
@@ -247,7 +247,7 @@ def write_tags(
             tag_langs = languages
         audiofile.tag.setTextFrame(LANGUAGE_FID, delimiter.join(tag_langs))
     if published_date and (always_overwrite or not audiofile.tag.release_date):
-        audiofile.tag.release_date = published_date
+        audiofile.tag.release_date = LibbyClient.parse_datetime(published_date).strftime("%Y-%m-%d")
     if cover_bytes:
         audiofile.tag.images.set(
             art.TO_ID3_ART_TYPES[art.FRONT_COVER][0],

--- a/odmpy/processing/shared.py
+++ b/odmpy/processing/shared.py
@@ -247,7 +247,9 @@ def write_tags(
             tag_langs = languages
         audiofile.tag.setTextFrame(LANGUAGE_FID, delimiter.join(tag_langs))
     if published_date and (always_overwrite or not audiofile.tag.release_date):
-        audiofile.tag.release_date = LibbyClient.parse_datetime(published_date).strftime("%Y-%m-%d")
+        audiofile.tag.release_date = LibbyClient.parse_datetime(
+            published_date
+        ).strftime("%Y-%m-%d")
     if cover_bytes:
         audiofile.tag.images.set(
             art.TO_ID3_ART_TYPES[art.FRONT_COVER][0],


### PR DESCRIPTION
Fixing issue noted in #58 
Libby is now using `"%Y-%m-%dT%H:%M:%S%z` format for the published_date. This needs to be converted to `%Y-%M-%D` to be added to ID3 tags.

Additionally, fixed mypy `union-attr` errors