### PR TITLE
Fix download using spine information from window.bData

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" , "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10" , "3.11" , "3.12" ]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -36,7 +36,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         pip -q install -r requirements.txt
         pip -q install -r requirements-dev.txt
     - name: Compile all
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [ "3.7", "3.8", "3.9", "3.10" , "3.11" ]
+        python-version: [ "3.8", "3.8", "3.9", "3.10" , "3.11" , "3.12" ]
     needs: lint
     steps:
     - uses: FedericoCarboni/setup-ffmpeg@v2
@@ -80,7 +80,7 @@ jobs:
     - name: Install dependencies
       # Installing wheel due to https://github.com/pypa/pip/issues/8559
       run: |
-        python3 -m pip -q install --upgrade pip wheel
+        python3 -m pip -q install --upgrade pip wheel setuptools
         python3 -m pip -q install -r requirements.txt --upgrade
         python3 -m pip -q install -r requirements-dev.txt --upgrade
     - name: Run tests on ${{ matrix.os }} with python ${{ matrix.python-version }}
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ odmpy also has useful features for audiobooks such as adding of chapters metadat
 
 Works on Linux, macOS, and Windows.
 
-Requires Python >= 3.7.
+Requires Python >= 3.8.
 
 ![Screenshot](https://user-images.githubusercontent.com/104607/222746903-0089bea5-ba3f-4eef-8e14-b4870a5bbb27.png)
 

--- a/odmpy/libby.py
+++ b/odmpy/libby.py
@@ -136,9 +136,9 @@ def parse_part_path(title: str, part_path: str) -> ChapterMarker:
     return ChapterMarker(
         title=title,
         part_name=mobj.group("part_name"),
-        start_second=float(mobj.group("second_stamp"))
-        if mobj.group("second_stamp")
-        else 0,
+        start_second=(
+            float(mobj.group("second_stamp")) if mobj.group("second_stamp") else 0
+        ),
         end_second=0,
     )
 

--- a/odmpy/libby.py
+++ b/odmpy/libby.py
@@ -812,16 +812,26 @@ class LibbyClient(object):
         meta = self.open_loan(loan_type, card_id, title_id)
         download_base: str = meta["urls"]["web"]
 
-        # Sets a needed cookie
+        # Sets a needed cookie and parse the redirect HTML for meta.
         web_url = download_base + "?" + meta["message"]
-        _ = self.make_request(
+        html = self.make_request(
             web_url,
             headers={"Accept": "*/*"},
-            method="HEAD",
+            method="GET",
             authenticated=False,
             return_res=True,
         )
-        return download_base, meta
+        # audio [nav/toc, spine], ebook [nav/toc, spine, manifest]
+        # both in window.bData
+        regex = re.compile(r"window\.bData\s*=\s*({.*});")
+        match = regex.search(html.text)
+        if not match:
+            raise ValueError(f"Failed to parse window.bData for book info: {web_url}")
+        openbook = json.loads(match.group(1))
+
+        # set download_base for ebook
+        openbook["download_base"] = download_base
+        return download_base, openbook
 
     def process_audiobook(
         self, loan: Dict
@@ -832,24 +842,19 @@ class LibbyClient(object):
         :param loan:
         :return:
         """
-        download_base, meta = self.prepare_loan(loan)
-        # contains nav/toc and spine
-        openbook = self.make_request(meta["urls"]["openbook"])
+        download_base, openbook = self.prepare_loan(loan)
         toc = parse_toc(download_base, openbook["nav"]["toc"], openbook["spine"])
         return openbook, toc
 
-    def process_ebook(self, loan: Dict) -> Tuple[str, Dict, List[Dict]]:
+    def process_ebook(self, loan: Dict) -> Tuple[str, Dict]:
         """
         Returns the data needed to download an ebook directly.
 
         :param loan:
         :return:
         """
-        download_base, meta = self.prepare_loan(loan)
-        # contains nav/toc and spine, manifest
-        openbook = self.make_request(meta["urls"]["openbook"])
-        rosters: List[Dict] = self.make_request(meta["urls"]["rosters"])
-        return download_base, openbook, rosters
+        download_base, openbook = self.prepare_loan(loan)
+        return download_base, openbook
 
     def return_title(self, title_id: str, card_id: str) -> None:
         """

--- a/odmpy/libby_errors.py
+++ b/odmpy/libby_errors.py
@@ -77,8 +77,8 @@ class ErrorHandler(object):
         :return:
         """
         # json response
-        if http_err.response is not None :
-            if hasattr(http_err.response, 'json') and callable(http_err.response.json):
+        if http_err.response is not None:
+            if hasattr(http_err.response, "json") and callable(http_err.response.json):
                 if (
                     http_err.response.status_code == HTTPStatus.BAD_REQUEST
                     and http_err.response.headers.get("content-type", "").startswith(
@@ -100,7 +100,7 @@ class ErrorHandler(object):
                             http_status=http_err.response.status_code,
                             error_response=http_err.response.text,
                         ) from http_err
-                    
+
                 # final fallback
                 raise ClientError(
                     msg=str(http_err),

--- a/odmpy/libby_errors.py
+++ b/odmpy/libby_errors.py
@@ -77,31 +77,33 @@ class ErrorHandler(object):
         :return:
         """
         # json response
-        if (
-            http_err.response.status_code == HTTPStatus.BAD_REQUEST
-            and http_err.response.headers.get("content-type", "").startswith(
-                "application/json"
-            )
-        ):
-            error = http_err.response.json()
-            if error.get("result", "") == "upstream_failure":
-                upstream = error.get("upstream", {})
-                if upstream:
-                    raise ClientBadRequestError(
-                        msg=f'{upstream.get("userExplanation", "")} [errorcode: {upstream.get("errorCode", "")}]',
-                        http_status=http_err.response.status_code,
-                        error_response=http_err.response.text,
-                    ) from http_err
+        if http_err.response is not None :
+            if hasattr(http_err.response, 'json') and callable(http_err.response.json):
+                if (
+                    http_err.response.status_code == HTTPStatus.BAD_REQUEST
+                    and http_err.response.headers.get("content-type", "").startswith(
+                        "application/json"
+                    )
+                ):
+                    error = http_err.response.json()
+                    if error.get("result", "") == "upstream_failure":
+                        upstream = error.get("upstream", {})
+                        if upstream:
+                            raise ClientBadRequestError(
+                                msg=f'{upstream.get("userExplanation", "")} [errorcode: {upstream.get("errorCode", "")}]',
+                                http_status=http_err.response.status_code,
+                                error_response=http_err.response.text,
+                            ) from http_err
 
-                raise ClientBadRequestError(
-                    msg=str(error),
+                        raise ClientBadRequestError(
+                            msg=str(error),
+                            http_status=http_err.response.status_code,
+                            error_response=http_err.response.text,
+                        ) from http_err
+                    
+                # final fallback
+                raise ClientError(
+                    msg=str(http_err),
                     http_status=http_err.response.status_code,
                     error_response=http_err.response.text,
                 ) from http_err
-
-        # final fallback
-        raise ClientError(
-            msg=str(http_err),
-            http_status=http_err.response.status_code,
-            error_response=http_err.response.text,
-        ) from http_err

--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -394,9 +394,7 @@ def extract_loan_file(
         file_ext = (
             "acsm"
             if format_id in (LibbyFormats.EBookEPubAdobe, LibbyFormats.EBookPDFAdobe)
-            else "pdf"
-            if format_id == LibbyFormats.EBookPDFOpen
-            else "epub"
+            else "pdf" if format_id == LibbyFormats.EBookPDFOpen else "epub"
         )
         book_folder, book_file_name = generate_names(
             title=selected_loan["title"],
@@ -1028,18 +1026,26 @@ def run(custom_args: Optional[List[str]] = None, be_quiet: bool = False) -> None
                     "%s: %-55s  %s %-25s  \n    * %s  %s%s",
                     colored(f"{index:2d}", attrs=["bold"]),
                     colored(loan["title"], attrs=["bold"]),
-                    "📰"
-                    if args.include_magazines
-                    and libby_client.is_downloadable_magazine_loan(loan)
-                    else "📕"
-                    if args.include_ebooks
-                    and libby_client.is_downloadable_ebook_loan(loan)
-                    else "🎧"
-                    if args.include_ebooks or args.include_magazines
-                    else "",
-                    loan["firstCreatorName"]
-                    if loan.get("firstCreatorName")
-                    else loan.get("edition", ""),
+                    (
+                        "📰"
+                        if args.include_magazines
+                        and libby_client.is_downloadable_magazine_loan(loan)
+                        else (
+                            "📕"
+                            if args.include_ebooks
+                            and libby_client.is_downloadable_ebook_loan(loan)
+                            else (
+                                "🎧"
+                                if args.include_ebooks or args.include_magazines
+                                else ""
+                            )
+                        )
+                    ),
+                    (
+                        loan["firstCreatorName"]
+                        if loan.get("firstCreatorName")
+                        else loan.get("edition", "")
+                    ),
                     f"Expires: {colored(f'{expiry_date:%Y-%m-%d}','blue' if libby_client.is_renewable(loan) else None)}",
                     next(
                         iter(
@@ -1050,13 +1056,15 @@ def run(custom_args: Optional[List[str]] = None, be_quiet: bool = False) -> None
                             ]
                         )
                     ),
-                    ""
-                    if not libby_client.is_renewable(loan)
-                    else (
-                        f'\n    * {loan.get("availableCopies", 0)} '
-                        f'{ps(loan.get("availableCopies", 0), "copy", "copies")} available'
-                    )
-                    + (f" (hold placed: {hold_date:%Y-%m-%d})" if hold else ""),
+                    (
+                        ""
+                        if not libby_client.is_renewable(loan)
+                        else (
+                            f'\n    * {loan.get("availableCopies", 0)} '
+                            f'{ps(loan.get("availableCopies", 0), "copy", "copies")} available'
+                        )
+                        + (f" (hold placed: {hold_date:%Y-%m-%d})" if hold else "")
+                    ),
                 )
             loan_choices: List[str] = []
 

--- a/odmpy/odm.py
+++ b/odmpy/odm.py
@@ -377,11 +377,10 @@ def extract_loan_file(
         format_id = LibbyFormats.EBookOverdrive
 
     openbook: Dict = {}
-    rosters: List[Dict] = []
     # pre-extract openbook first so that we can use it to create the book folder
     # with the creator names (needed to place the cover.jpg download)
     if format_id in (LibbyFormats.EBookOverdrive, LibbyFormats.MagazineOverDrive):
-        _, openbook, rosters = libby_client.process_ebook(selected_loan)
+        _, openbook = libby_client.process_ebook(selected_loan)
 
     cover_path = None
     if format_id in (
@@ -443,7 +442,6 @@ def extract_loan_file(
                 loan=selected_loan,
                 cover_path=cover_path,
                 openbook=openbook,
-                rosters=rosters,
                 libby_client=libby_client,
                 args=args,
                 logger=logger,

--- a/odmpy/processing/audiobook.py
+++ b/odmpy/processing/audiobook.py
@@ -214,9 +214,11 @@ def process_audiobook_loan(
                     part_download_url,
                     headers={
                         "User-Agent": USER_AGENT,
-                        "Range": f"bytes={already_downloaded_len}-"
-                        if already_downloaded_len
-                        else None,
+                        "Range": (
+                            f"bytes={already_downloaded_len}-"
+                            if already_downloaded_len
+                            else None
+                        ),
                     },
                     timeout=args.timeout,
                     stream=True,
@@ -478,15 +480,19 @@ def process_audiobook_loan(
             create_opf(
                 media_info,
                 cover_filename if keep_cover else None,
-                file_tracks
-                if not args.merge_output
-                else [
-                    {
-                        "file": book_filename
-                        if args.merge_format == "mp3"
-                        else book_m4b_filename
-                    }
-                ],
+                (
+                    file_tracks
+                    if not args.merge_output
+                    else [
+                        {
+                            "file": (
+                                book_filename
+                                if args.merge_format == "mp3"
+                                else book_m4b_filename
+                            )
+                        }
+                    ]
+                ),
                 opf_file_path,
                 logger,
             )

--- a/odmpy/processing/audiobook.py
+++ b/odmpy/processing/audiobook.py
@@ -245,8 +245,9 @@ def process_audiobook_loan(
                 )
 
             except HTTPError as he:
-                logger.error(f"HTTPError: {str(he)}")
-                logger.debug(he.response.content)
+                if he.response is not None :
+                    logger.error(f"HTTPError: {str(he)}")
+                    logger.debug(he.response.content)
                 raise OdmpyRuntimeError("HTTP Error while downloading part file.")
 
             except ConnectionError as ce:

--- a/odmpy/processing/audiobook.py
+++ b/odmpy/processing/audiobook.py
@@ -245,7 +245,7 @@ def process_audiobook_loan(
                 )
 
             except HTTPError as he:
-                if he.response is not None :
+                if he.response is not None:
                     logger.error(f"HTTPError: {str(he)}")
                     logger.debug(he.response.content)
                 raise OdmpyRuntimeError("HTTP Error while downloading part file.")

--- a/odmpy/processing/ebook.py
+++ b/odmpy/processing/ebook.py
@@ -861,7 +861,7 @@ def process_ebook_loan(
 
     # Ignoring mypy error below because of https://github.com/python/mypy/issues/9372
     spine_entries = sorted(
-        spine_entries, key=cmp_to_key(lambda a, b: _sort_spine_entries(a, b, toc_pages))  # type: ignore[misc]
+        spine_entries, key=cmp_to_key(lambda a, b: _sort_spine_entries(a, b, toc_pages))  # type: ignore[misc,arg-type]
     )
     for spine_idx, entry in enumerate(spine_entries):
         if (

--- a/odmpy/processing/ebook.py
+++ b/odmpy/processing/ebook.py
@@ -646,6 +646,24 @@ def process_ebook_loan(
             else:
                 with open(asset_file_path, "wb") as f_out:
                     f_out.write(res.content)
+        
+        # download image to asset dir from decoded HTML
+        # e.g. '<img src="***_003_r1.jpg" alt="003" class="imgepub" data-loc="60">'
+        if soup:
+            image_url = soup.find("img", attrs={"src": True})
+            if image_url:
+                image_url = urljoin(parsed_entry_url.geturl(), image_url["src"])
+                image_url = urlparse(image_url)
+                image_url = image_url.geturl()
+                # ready to download
+                image_file_name = os.path.basename(image_url)
+                image_file_path = asset_folder.joinpath(image_file_name)
+                if not image_file_path.exists():
+                    logger.info(f"Downloading {image_url} to {image_file_path}")
+                    res = libby_client.make_request(image_url, return_res=True)
+                    with open(image_file_path, "wb") as f_out:
+                        f_out.write(res.content)
+
 
         if soup:
             # try to min. soup searches where possible

--- a/odmpy/processing/odm.py
+++ b/odmpy/processing/odm.py
@@ -431,9 +431,11 @@ def process_odm(
                         "User-Agent": UA,
                         "ClientID": license_client_id,
                         "License": lic_file_contents,
-                        "Range": f"bytes={already_downloaded_len}-"
-                        if already_downloaded_len
-                        else None,
+                        "Range": (
+                            f"bytes={already_downloaded_len}-"
+                            if already_downloaded_len
+                            else None
+                        ),
                     },
                     timeout=args.timeout,
                     stream=True,
@@ -791,15 +793,19 @@ def process_odm(
                 create_opf(
                     media_info,
                     cover_filename if keep_cover else None,
-                    file_tracks
-                    if not args.merge_output
-                    else [
-                        {
-                            "file": book_filename
-                            if args.merge_format == "mp3"
-                            else book_m4b_filename
-                        }
-                    ],
+                    (
+                        file_tracks
+                        if not args.merge_output
+                        else [
+                            {
+                                "file": (
+                                    book_filename
+                                    if args.merge_format == "mp3"
+                                    else book_m4b_filename
+                                )
+                            }
+                        ]
+                    ),
                     opf_file_path,
                     logger,
                 )

--- a/odmpy/processing/odm.py
+++ b/odmpy/processing/odm.py
@@ -372,14 +372,15 @@ def process_odm(
             logger.debug(f"Saved license file {license_file}")
 
         except HTTPError as he:
-            if he.response.status_code == 404:
-                # odm file has expired
-                logger.error(
-                    f'The loan file "{args.odm_file}" has expired. Please download again.'
-                )
-            else:
-                logger.error(he.response.content)
-            raise OdmpyRuntimeError("HTTP Error while downloading license.")
+            if he.response is not None :
+                if he.response.status_code == 404:
+                    # odm file has expired
+                    logger.error(
+                        f'The loan file "{args.odm_file}" has expired. Please download again.'
+                    )
+                else:
+                    logger.error(he.response.content)
+                raise OdmpyRuntimeError("HTTP Error while downloading license.")
         except ConnectionError as ce:
             logger.error(f"ConnectionError: {str(ce)}")
             raise OdmpyRuntimeError("Connection Error while downloading license.")
@@ -461,8 +462,9 @@ def process_odm(
                 )
 
             except HTTPError as he:
-                logger.error(f"HTTPError: {str(he)}")
-                logger.debug(he.response.content)
+                if he.response is not None :
+                    logger.error(f"HTTPError: {str(he)}")
+                    logger.debug(he.response.content)
                 raise OdmpyRuntimeError("HTTP Error while downloading part file.")
 
             except ConnectionError as ce:
@@ -832,11 +834,12 @@ def process_odm_return(args: argparse.Namespace, logger: logging.Logger) -> None
         early_return_res.raise_for_status()
         logger.info(f"Loan returned successfully: {args.odm_file}")
     except HTTPError as he:
-        if he.response.status_code == 403:
-            logger.warning("Loan is probably already returned.")
-            return
-        logger.error(f"HTTPError: {str(he)}")
-        logger.debug(he.response.content)
+        if he.response is not None :
+            if he.response.status_code == 403:
+                logger.warning("Loan is probably already returned.")
+                return
+            logger.error(f"HTTPError: {str(he)}")
+            logger.debug(he.response.content)
         raise OdmpyRuntimeError(f"HTTP error returning odm {args.odm_file, }")
     except ConnectionError as ce:
         logger.error(f"ConnectionError: {str(ce)}")

--- a/odmpy/processing/odm.py
+++ b/odmpy/processing/odm.py
@@ -372,7 +372,7 @@ def process_odm(
             logger.debug(f"Saved license file {license_file}")
 
         except HTTPError as he:
-            if he.response is not None :
+            if he.response is not None:
                 if he.response.status_code == 404:
                     # odm file has expired
                     logger.error(
@@ -462,7 +462,7 @@ def process_odm(
                 )
 
             except HTTPError as he:
-                if he.response is not None :
+                if he.response is not None:
                     logger.error(f"HTTPError: {str(he)}")
                     logger.debug(he.response.content)
                 raise OdmpyRuntimeError("HTTP Error while downloading part file.")
@@ -834,7 +834,7 @@ def process_odm_return(args: argparse.Namespace, logger: logging.Logger) -> None
         early_return_res.raise_for_status()
         logger.info(f"Loan returned successfully: {args.odm_file}")
     except HTTPError as he:
-        if he.response is not None :
+        if he.response is not None:
             if he.response.status_code == 403:
                 logger.warning("Loan is probably already returned.")
                 return

--- a/odmpy/processing/shared.py
+++ b/odmpy/processing/shared.py
@@ -125,9 +125,11 @@ def generate_names(
         # create book folder with just the title and first author
         book_folder_name = args.book_folder_format % {
             "Title": sanitize_path(title, exclude_chars=args.remove_from_paths),
-            "Author": sanitize_path(authors[0], exclude_chars=args.remove_from_paths)
-            if authors
-            else "",
+            "Author": (
+                sanitize_path(authors[0], exclude_chars=args.remove_from_paths)
+                if authors
+                else ""
+            ),
             "Series": sanitize_path(series or "", exclude_chars=args.remove_from_paths),
             "ID": sanitize_path(title_id, exclude_chars=args.remove_from_paths),
             "ReadingOrder": sanitize_path(
@@ -407,9 +409,9 @@ def merge_into_mp3(
             "-vcodec",
             "copy",
             "-b:a",
-            f"{audio_bitrate}k"
-            if audio_bitrate
-            else "64k",  # explicitly set audio bitrate
+            (
+                f"{audio_bitrate}k" if audio_bitrate else "64k"
+            ),  # explicitly set audio bitrate
             "-f",
             "mp3",
             str(temp_book_filename),
@@ -474,9 +476,9 @@ def convert_to_m4b(
             "-c:a",
             merge_codec,
             "-b:a",
-            f"{audio_bitrate}k"
-            if audio_bitrate
-            else "64k",  # explicitly set audio bitrate
+            (
+                f"{audio_bitrate}k" if audio_bitrate else "64k"
+            ),  # explicitly set audio bitrate
         ]
     )
     if cover_filename.exists():

--- a/odmpy/processing/shared.py
+++ b/odmpy/processing/shared.py
@@ -247,7 +247,7 @@ def write_tags(
             tag_langs = languages
         audiofile.tag.setTextFrame(LANGUAGE_FID, delimiter.join(tag_langs))
     if published_date and (always_overwrite or not audiofile.tag.release_date):
-        audiofile.tag.release_date = published_date
+        audiofile.tag.release_date = LibbyClient.parse_datetime(published_date).strftime("%Y-%m-%d")
     if cover_bytes:
         audiofile.tag.images.set(
             art.TO_ID3_ART_TYPES[art.FRONT_COVER][0],

--- a/odmpy/processing/shared.py
+++ b/odmpy/processing/shared.py
@@ -247,7 +247,9 @@ def write_tags(
             tag_langs = languages
         audiofile.tag.setTextFrame(LANGUAGE_FID, delimiter.join(tag_langs))
     if published_date and (always_overwrite or not audiofile.tag.release_date):
-        audiofile.tag.release_date = LibbyClient.parse_datetime(published_date).strftime("%Y-%m-%d")
+        audiofile.tag.release_date = LibbyClient.parse_datetime(
+            published_date
+        ).strftime("%Y-%m-%d")
     if cover_bytes:
         audiofile.tag.images.set(
             art.TO_ID3_ART_TYPES[art.FRONT_COVER][0],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with odmpy.  If not, see <http://www.gnu.org/licenses/>.
 #
-import sys
 
 from setuptools import setup  # type: ignore[import]
 
@@ -38,8 +37,6 @@ install_requires = [
     "lxml>=4.9.0",
     "iso639-lang>=2.1.0",
 ]
-if sys.version_info < (3, 8):
-    install_requires.append("typing_extensions")
 
 setup(
     name="odmpy",
@@ -53,7 +50,7 @@ setup(
             "odmpy = odmpy.__main__:main",
         ]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=install_requires,
     include_package_data=True,
     platforms="any",
@@ -70,5 +67,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -14,9 +14,11 @@ class UtilsTests(unittest.TestCase):
     def test_sanitize_path(self):
         self.assertEqual(
             utils.sanitize_path(r'a<b>c:d"e/f\g|h?i*j_a<b>c:d"e/f\g|h?i*j', ""),
-            "abcdefghij_abcdefghij"
-            if is_windows
-            else r'a<b>c:d"ef\g|h?i*j_a<b>c:d"ef\g|h?i*j',
+            (
+                "abcdefghij_abcdefghij"
+                if is_windows
+                else r'a<b>c:d"ef\g|h?i*j_a<b>c:d"ef\g|h?i*j'
+            ),
         )
         self.assertEqual(
             utils.sanitize_path(r'a<b>c:d"e/f\g|h?i*j'),


### PR DESCRIPTION
This is similar to my another [PR](https://github.com/bookbonobo/libby-download-extension/pull/195) for the new format, the branch is based on #59 

audiobooks work just fine with command `odmpy libby --ebooks --direct --chapters --merge`

for epub books command is the same, and I picked a small one to test locally, 
* it can generate an EPUB correctly with ToC, text styles like bold and italic are preserved(since they are from base64-encoded HTML?)
* images are also saved, but they didn't exist in `bData` anymore, I'm not 100% satisfied with the way they are downloaded. e.g. when image src is `../Images/cover.jpg`, it can still be downloaded, but need a fix on HTML to display, instead of preserving the origin file hierarchy
* CSS is downloaded similarly

There are 2 commits trying to make CI happy, but apprently CI isn't that easy to please: linter passed, tests hardcoded the outdated `openbook.json` and should be fixed as well